### PR TITLE
fix rebootRequired messaging during interactive runs

### DIFF
--- a/install.go
+++ b/install.go
@@ -179,6 +179,7 @@ func (i *installCmd) installUpdates() error {
 		if rebootRequired {
 			if i.Interactive {
 				fmt.Println("Host has existing updates pending reboot.")
+				rebootEvent <- rebootRequired
 				return nil
 			}
 			t, err := cablib.RebootTime()
@@ -349,6 +350,7 @@ func (i *installCmd) installUpdates() error {
 	if rebootRequired {
 		if i.Interactive {
 			fmt.Println("Updates have been installed, please reboot to complete the installation...")
+			rebootEvent <- rebootRequired
 			return nil
 		}
 		rebootMessage(int(config.RebootDelay))


### PR DESCRIPTION
Old: 
Host has existing updates pending reboot.
No reboot needed.

New: 
Host has existing updates pending reboot.
Please reboot to finalize the update installation.